### PR TITLE
feat: list other demos on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,59 +1,72 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Interactive Vector Demos</title>
-    <link rel="stylesheet" href="layouts/styles.css" />
-    <link rel="stylesheet" href="layouts/home.css" />
-</head>
-<body>
-    <div id="nav_placeholder"></div>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Interactive Vector Demos</title>
+        <link rel="stylesheet" href="layouts/styles.css" />
+        <link rel="stylesheet" href="layouts/home.css" />
+    </head>
+    <body>
+        <div id="nav_placeholder"></div>
 
-    <div class="container">
-        <h1>Explore interactive vector demos</h1>
-        <p>Browse the collection below or search for a specific demo.</p>
-        <input type="text" id="demo-search" class="demo-search" placeholder="Search demos..." />
-        <div class="demo-grid">
-            <a href="projections.html" class="demo-card">
-                <img src="https://via.placeholder.com/300x150" alt="Projections Demo thumbnail" />
-                <h2>Projections Demo</h2>
-                <p>Visualise the projection of one vector onto another.</p>
-            </a>
-            <a href="triangle.html" class="demo-card">
-                <img src="https://via.placeholder.com/300x150" alt="Triangle proof thumbnail" />
-                <h2>Triangle Proof Demo</h2>
-                <p>Explore a geometric proof involving triangle midpoints.</p>
-            </a>
-            <a href="quad.html" class="demo-card">
-                <img src="https://via.placeholder.com/300x150" alt="Quadrilateral proof thumbnail" />
-                <h2>Parallelogram Demo</h2>
-                <p>Manipulate points to see how a parallelogram is formed.</p>
-            </a>
-            <a href="playground.html" class="demo-card">
-                <img src="https://via.placeholder.com/300x150" alt="Vector playground thumbnail" />
-                <h2>Vector Playground</h2>
-                <p>Experiment freely with 2D vectors.</p>
-            </a>
+        <div class="container">
+            <h1>Explore interactive vector demos</h1>
+            <p>Browse the collection below or search for a specific demo.</p>
+            <input type="text" id="demo-search" class="demo-search" placeholder="Search demos..." />
+            <div class="demo-grid">
+                <a href="projections.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Projections Demo thumbnail" />
+                    <h2>Projections Demo</h2>
+                    <p>Visualise the projection of one vector onto another.</p>
+                </a>
+                <a href="triangle.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Triangle proof thumbnail" />
+                    <h2>Triangle Proof Demo</h2>
+                    <p>Explore a geometric proof involving triangle midpoints.</p>
+                </a>
+                <a href="quad.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Quadrilateral proof thumbnail" />
+                    <h2>Parallelogram Demo</h2>
+                    <p>Manipulate points to see how a parallelogram is formed.</p>
+                </a>
+                <a href="playground.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Vector playground thumbnail" />
+                    <h2>Vector Playground</h2>
+                    <p>Experiment freely with 2D vectors.</p>
+                </a>
+            </div>
+            <h2>Other</h2>
+            <div class="demo-grid">
+                <a href="matrix_transform.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Matrix transformation visualiser thumbnail" />
+                    <h2>Matrix Transformation Visualiser</h2>
+                    <p>Visualise 2D matrix transformations.</p>
+                </a>
+                <a href="lol.html" class="demo-card">
+                    <img src="https://via.placeholder.com/300x150" alt="Roulette game thumbnail" />
+                    <h2>Roulette Game</h2>
+                    <p>Try your luck in a simple roulette game.</p>
+                </a>
+            </div>
         </div>
-    </div>
 
-    <div id="footer_placeholder"></div>
+        <div id="footer_placeholder"></div>
 
-    <script src="layouts/load_templates.js"></script>
-    <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const searchInput = document.getElementById('demo-search');
-        if (searchInput) {
-            searchInput.addEventListener('input', () => {
-                const query = searchInput.value.toLowerCase();
-                document.querySelectorAll('.demo-card').forEach(card => {
-                    const text = card.innerText.toLowerCase();
-                    card.style.display = text.includes(query) ? 'block' : 'none';
-                });
-            });
-        }
-    });
-    </script>
-</body>
+        <script src="layouts/load_templates.js"></script>
+        <script>
+            document.addEventListener("DOMContentLoaded", () => {
+                const searchInput = document.getElementById("demo-search")
+                if (searchInput) {
+                    searchInput.addEventListener("input", () => {
+                        const query = searchInput.value.toLowerCase()
+                        document.querySelectorAll(".demo-card").forEach((card) => {
+                            const text = card.innerText.toLowerCase()
+                            card.style.display = text.includes(query) ? "block" : "none"
+                        })
+                    })
+                }
+            })
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
## Summary
- add "Other" section to home page for extra demos
- link matrix transformation visualiser and roulette game

## Testing
- `npx prettier -w index.html`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3855559fc83289222f3575f9dce9d